### PR TITLE
Added confirmations attribute to Transaction.UnspentOutput

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@ bitcore.min.js
 bitcore.js.sig
 bitcore.min.js.sig
 tests.js
+
+.idea

--- a/lib/transaction/unspentoutput.js
+++ b/lib/transaction/unspentoutput.js
@@ -23,6 +23,7 @@ var Unit = require('../unit');
  * @param {number} data.amount amount of bitcoins associated
  * @param {number=} data.satoshis alias for `amount`, but expressed in satoshis (1 BTC = 1e8 satoshis)
  * @param {string|Address=} data.address the associated address to the script, if provided
+ * @param {number} the number of confirmations, if provided
  */
 function UnspentOutput(data) {
   /* jshint maxcomplexity: 20 */
@@ -48,12 +49,14 @@ function UnspentOutput(data) {
                   'Must provide an amount for the output');
   var amount = !_.isUndefined(data.amount) ? new Unit.fromBTC(data.amount).toSatoshis() : data.satoshis;
   $.checkArgument(_.isNumber(amount), 'Amount must be a number');
+  var confirmations = data.confirmations ? data.confirmations : undefined;
   JSUtil.defineImmutable(this, {
     address: address,
     txId: txId,
     outputIndex: outputIndex,
     script: script,
-    satoshis: amount
+    satoshis: amount,
+    confirmations: confirmations
   });
 }
 
@@ -63,7 +66,7 @@ function UnspentOutput(data) {
  */
 UnspentOutput.prototype.inspect = function() {
   return '<UnspentOutput: ' + this.txId + ':' + this.outputIndex +
-         ', satoshis: ' + this.satoshis + ', address: ' + this.address + '>';
+         ', satoshis: ' + this.satoshis + ', address: ' + this.address + ', confirmations: ' + this.confirmations + '>';
 };
 
 /**
@@ -93,7 +96,8 @@ UnspentOutput.prototype.toObject = UnspentOutput.prototype.toJSON = function toO
     txid: this.txId,
     vout: this.outputIndex,
     scriptPubKey: this.script.toBuffer().toString('hex'),
-    amount: Unit.fromSatoshis(this.satoshis).toBTC()
+    amount: Unit.fromSatoshis(this.satoshis).toBTC(),
+    confirmations: this.confirmations
   };
 };
 

--- a/package.json
+++ b/package.json
@@ -58,6 +58,10 @@
     {
       "name": "Wei Lu",
       "email": "luwei.here@gmail.com"
+    },
+    {
+      "name": "Michael Rodriguez",
+      "email": "michael@rodtec.org"
     }
   ],
   "keywords": [

--- a/test/transaction/unspentoutput.js
+++ b/test/transaction/unspentoutput.js
@@ -15,14 +15,16 @@ describe('UnspentOutput', function() {
     'txId': 'a477af6b2667c29670467e4e0728b685ee07b240235771862318e29ddbe58458',
     'outputIndex': 0,
     'script': 'OP_DUP OP_HASH160 20 0x88d9931ea73d60eaf7e5671efc0552b912911f2a OP_EQUALVERIFY OP_CHECKSIG',
-    'satoshis': 1020000
+    'satoshis': 1020000,
+    'confirmations': 100
   };
   var sampleData2 = {
     'txid': 'e42447187db5a29d6db161661e4bc66d61c3e499690fe5ea47f87b79ca573986',
     'vout': 1,
     'address': 'mgBCJAsvzgT2qNNeXsoECg2uPKrUsZ76up',
     'scriptPubKey': '76a914073b7eae2823efa349e3b9155b8a735526463a0f88ac',
-    'amount': 0.01080000
+    'amount': 0.01080000,
+    'confirmations': 50
   };
 
   it('roundtrip from raw data', function() {
@@ -49,7 +51,7 @@ describe('UnspentOutput', function() {
 
   it('displays nicely on the console', function() {
     var expected = '<UnspentOutput: a477af6b2667c29670467e4e0728b685ee07b240235771862318e29ddbe58458:0' +
-                   ', satoshis: 1020000, address: mszYqVnqKoQx4jcTdJXxwKAissE3Jbrrc1>';
+                   ', satoshis: 1020000, address: mszYqVnqKoQx4jcTdJXxwKAissE3Jbrrc1, confirmations: 100>';
     expect(new UnspentOutput(sampleData1).inspect()).to.equal(expected);
   });
 


### PR DESCRIPTION
Adding the confirmations data to the Transaction.UnspentOutput object which can later be used by litecore-explorers to specify a minconf on insight.getUtxos