### PR TITLE
xpubkey can not export right  xpub

### DIFF
--- a/lib/networks.js
+++ b/lib/networks.js
@@ -158,8 +158,8 @@ addNetwork({
   pubkeyhash: 0x6f,
   privatekey: 0xef,
   scripthash: 0x3a,
-  xpubkey: 0x0436f6e1,
-  xprivkey: 0x0436ef7d
+  xpubkey: 0x043587cf, //update for testnet 
+  xprivkey: 0x04358394 //update for testnet 
 });
 
 /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "litecore-lib",
-  "version": "0.13.21",
+  "name": "litecore-lib-st",
+  "version": "0.1.0",
   "description": "A pure and powerful JavaScript Litecoin library.",
   "author": "BitPay <dev@bitpay.com>",
   "main": "index.js",
@@ -83,7 +83,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/litecoin-project/litecore-lib.git"
+    "url": "https://github.com/Bjblue/litecore-lib-st.git"
   },
   "browser": {
     "request": "browser-request"


### PR DESCRIPTION
in bip39  testnet xpubkey and xprivkey can not export right xpub. 
update to btc testnet xpubkey and xprivkey is correct data.